### PR TITLE
Improving filename matching between FTPFile and FTPPath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .project
 src/site/markdown/index.md
 target
+.idea/
+ftp-fs.iml


### PR DESCRIPTION
The equals check between FTPFile.getName() and FTPPath.fileName() isn't enough, because FTPFile.getName() returns a full path (despite the documentation).