### PR TITLE
Fix for possible ftp connection pool starvation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .project
 src/site/markdown/index.md
 target
+.idea/

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPClientPool.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPClientPool.java
@@ -17,6 +17,10 @@
 
 package com.github.robtimus.filesystems.ftp;
 
+import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPFile;
+import org.apache.commons.net.ftp.FTPFileFilter;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,9 +33,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import org.apache.commons.net.ftp.FTPClient;
-import org.apache.commons.net.ftp.FTPFile;
-import org.apache.commons.net.ftp.FTPFileFilter;
 
 /**
  * A pool of FTP clients, allowing multiple commands to be executed concurrently.
@@ -181,7 +182,14 @@ final class FTPClientPool {
         }
 
         private boolean isConnected() {
-            return client.isConnected();
+            boolean connected;
+            try {
+                keepAlive();
+                connected = client.isConnected();
+            } catch (Exception e) {
+                connected = false;
+            }
+            return connected;
         }
 
         private void disconnect() throws IOException {


### PR DESCRIPTION
There is a possible connection pool starvation in methods FTPClientPool.get() and FTPClientPool.getOrCreate(). The isConnected() check should be fail-safe, otherwise there is a possibility that the Client will never return to the pool.

In my case it's also important to check the connection with a keepAlive() call. Because my ftp server can drop idle connections.