### PR TITLE
Configurable filesystem strategy

### DIFF
--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPEnvironment.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPEnvironment.java
@@ -112,6 +112,7 @@ public class FTPEnvironment implements Map<String, Object>, Cloneable {
     private static final int DEFAULT_CLIENT_CONNECTION_COUNT = 5;
     private static final String CLIENT_CONNECTION_COUNT = "clientConnectionCount"; //$NON-NLS-1$
     private static final String FILE_SYSTEM_EXCEPTION_FACTORY = "fileSystemExceptionFactory"; //$NON-NLS-1$
+    private static final String FILE_SYSTEM_STRATEGY_FACTORY = "filesystemStrategyFactory"; //$NON-NLS-1$
     private static final String SUPPORT_ABSOLOTE_FILE_PATHS = "supportAbsoluteFilePaths"; //$NON-NLS-1$
     private static final String CALCULATE_ACTUAL_TOTAL_SPACE = "calculateActualTotalSpace"; //$NON-NLS-1$
 
@@ -603,6 +604,17 @@ public class FTPEnvironment implements Map<String, Object>, Cloneable {
     }
 
     /**
+     * Stores the file system strategy to use.
+     *
+     * @param factory The file system strategy to use.
+     * @return This object.
+     */
+    public FTPEnvironment withFileSystemStrategyFactory(FileSystemStrategyFactory factory) {
+        put(FILE_SYSTEM_STRATEGY_FACTORY, factory);
+        return this;
+    }
+
+    /**
      * Stores whether or not FTP servers support absolute paths to list files. If set to {@code false}, getting information about a file will list its
      * parent directory. If set to {@code true}, the server settings will determine how files are listed.
      * <p>
@@ -661,6 +673,13 @@ public class FTPEnvironment implements Map<String, Object>, Cloneable {
         return FileSystemProviderSupport.getValue(this, FILE_SYSTEM_EXCEPTION_FACTORY, FileSystemExceptionFactory.class,
                 DefaultFileSystemExceptionFactory.INSTANCE);
     }
+
+    FileSystemStrategyFactory getFileSystemStrategyFactory() {
+        return FileSystemProviderSupport.getValue(this, FILE_SYSTEM_STRATEGY_FACTORY, FileSystemStrategyFactory.class,
+                DefaultFileSystemStrategyFactory.INSTANCE);
+    }
+
+
 
     boolean supportAbsoluteFilePaths() {
         return FileSystemProviderSupport.getBooleanValue(this, SUPPORT_ABSOLOTE_FILE_PATHS, true);

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPFileSystem.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPFileSystem.java
@@ -93,7 +93,7 @@ class FTPFileSystem extends FileSystem {
     private final URI uri;
     private final String defaultDirectory;
 
-    private final FTPFileStrategy ftpFileStrategy;
+    private final FileSystemStrategy ftpFileStrategy;
 
     private final AtomicBoolean open = new AtomicBoolean(true);
 
@@ -110,7 +110,9 @@ class FTPFileSystem extends FileSystem {
             this.defaultDirectory = client.pwd();
 
             boolean supportAbsoluteFilePaths = env.supportAbsoluteFilePaths();
-            this.ftpFileStrategy = FTPFileStrategy.getInstance(client, supportAbsoluteFilePaths);
+            FileSystemStrategyFactory fileSystemStrategyFactory = env.getFileSystemStrategyFactory();
+            FileSystemStrategy filesystemStrategy = fileSystemStrategyFactory.createFilesystemStrategy(client, supportAbsoluteFilePaths);
+            this.ftpFileStrategy = filesystemStrategy;
         }
     }
 

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPFileSystemClient.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPFileSystemClient.java
@@ -1,0 +1,39 @@
+package com.github.robtimus.filesystems.ftp;
+
+import org.apache.commons.net.ftp.FTPFile;
+import org.apache.commons.net.ftp.FTPFileFilter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.OpenOption;
+import java.util.Calendar;
+import java.util.Collection;
+
+public interface FTPFileSystemClient {
+
+    void keepAlive() throws IOException;
+
+    String pwd() throws IOException;
+
+    InputStream newInputStream(String path, OpenOptions options) throws IOException;
+
+    OutputStream newOutputStream(String path, OpenOptions options) throws IOException;
+
+    void storeFile(String path, InputStream local, TransferOptions options, Collection<? extends OpenOption> openOptions) throws IOException;
+
+    FTPFile[] listFiles(String path) throws IOException;
+
+    FTPFile[] listFiles(String path, FTPFileFilter filter) throws IOException;
+
+    void throwIfEmpty(String path, FTPFile[] ftpFiles) throws IOException;
+
+    void mkdir(String path) throws IOException;
+
+    void delete(String path, boolean isDirectory) throws IOException;
+
+    void rename(String source, String target) throws IOException;
+
+    Calendar mdtm(String path) throws IOException;
+
+}

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPPath.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPPath.java
@@ -47,7 +47,7 @@ import com.github.robtimus.filesystems.SimpleAbstractPath;
  *
  * @author Rob Spoor
  */
-class FTPPath extends SimpleAbstractPath {
+public class FTPPath extends SimpleAbstractPath {
 
     private final FTPFileSystem fs;
 

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPSEnvironment.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPSEnvironment.java
@@ -321,6 +321,12 @@ public class FTPSEnvironment extends FTPEnvironment {
     }
 
     @Override
+    public FTPSEnvironment withFileSystemStrategyFactory(FileSystemStrategyFactory factory) {
+        super.withFileSystemStrategyFactory(factory);
+        return this;
+    }
+
+    @Override
     public FTPSEnvironment withAbsoluteFilePathSupport(boolean supportAbsoluteFilePaths) {
         super.withAbsoluteFilePathSupport(supportAbsoluteFilePaths);
         return this;

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FileSystemStrategy.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FileSystemStrategy.java
@@ -1,0 +1,41 @@
+package com.github.robtimus.filesystems.ftp;
+
+import org.apache.commons.net.ftp.FTPFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface FileSystemStrategy {
+
+    /**
+     * Find children directories.
+     *
+     * @param client
+     * @param path
+     * @return
+     * @throws IOException
+     */
+    List<FTPFile> getChildren(FTPFileSystemClient client, FTPPath path) throws IOException;
+
+    /**
+     * Find a ftp path.
+     *
+     * @param client
+     * @param path
+     * @return
+     * @throws IOException
+     */
+    FTPFile getFTPFile(FTPFileSystemClient client, FTPPath path) throws IOException;
+
+    /**
+     * Find a link.
+     *
+     * @param client
+     * @param ftpFile
+     * @param path
+     * @return
+     * @throws IOException
+     */
+    FTPFile getLink(FTPFileSystemClient client, FTPFile ftpFile, FTPPath path) throws IOException;
+
+}

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FileSystemStrategyFactory.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FileSystemStrategyFactory.java
@@ -1,0 +1,28 @@
+/*
+ * FileSystemExceptionFactory.java
+ * Copyright 2016 Rob Spoor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robtimus.filesystems.ftp;
+
+import java.io.IOException;
+
+/**
+ * A factory for creating {@link FileSystemStrategy}.
+ */
+public interface FileSystemStrategyFactory {
+
+    FileSystemStrategy createFilesystemStrategy(FTPFileSystemClient client, boolean supportAbsoluteFilePaths) throws IOException;
+}


### PR DESCRIPTION
Allow to plug a custom FileSystemStrategy by providing a factory to the FtpEnvironment.
This requires to export the ftp client & filesystem strategy.

In our case, using a custom strategy that caches the results during a directory traversal reduced the operation time by ~75%. It appears this was due to the the excessive client.list(`<file parent path>`) to get an instance of an ftp file at `<file path>`.