### PR TITLE
Add debug logs for easier connection leak detection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,13 @@
       <version>${version.commons-net}</version>
     </dependency>
 
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.slf4j}</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -144,13 +151,6 @@
       <groupId>org.mockftpserver</groupId>
       <artifactId>MockFtpServer</artifactId>
       <version>${version.MockFtpServer}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${version.slf4j}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
It is really easy to cause connection leak in client code. Like `Stream` returned from [`Files.lines()`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#lines-java.nio.file.Path-java.nio.charset.Charset-) should be close explicitly.

If there exists some debugging information in this lib, will be a great help to detect possible connection leak for users.