### PR TITLE
Ignore Eclipse files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .checkstyle
 .classpath
 .project
+.externalToolBuilders
 .idea
+maven-eclipse.xml
 src/site/markdown/index.md
 target


### PR DESCRIPTION
Using Maven to generate an Eclipse project produces addition files that should be ignored.