### PR TITLE
Support data channel protection level for FTPS.

### DIFF
--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPSDataChannelProtectionLevel.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPSDataChannelProtectionLevel.java
@@ -1,0 +1,43 @@
+/*
+ * FTPSDataChannelProtectionLevel.java
+ * Copyright 2020 Rob Spoor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robtimus.filesystems.ftp;
+
+/**
+ * Protection level of the data channel in a FTPS communication.
+ *
+ * <ul>
+ * <li>C - Clear</li>
+ * <li>S - Safe</li>
+ * <li>E - Confidential</li>
+ * <li>P - Private</li>
+ * </ul>
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc2228#section-3">RFC 2228, section 3</a>
+ * @author Joerg Schaible
+ */
+public enum FTPSDataChannelProtectionLevel
+{
+    /** Clear. */
+    C,
+    /** Safe. */
+    S,
+    /** Confidential. */
+    E,
+    /** Private. */
+    P;
+}

--- a/src/main/java/com/github/robtimus/filesystems/ftp/FTPSEnvironment.java
+++ b/src/main/java/com/github/robtimus/filesystems/ftp/FTPSEnvironment.java
@@ -63,6 +63,7 @@ public class FTPSEnvironment extends FTPEnvironment {
     private static final String USE_CLIENT_MODE = "useClientMode"; //$NON-NLS-1$
     private static final String ENABLED_CIPHER_SUITES = "enabledCipherSuites"; //$NON-NLS-1$
     private static final String ENABLED_PROTOCOLS = "enabledProtocols"; //$NON-NLS-1$
+    private static final String DATA_CHANNEL_PROTECTION_LEVEL = "dataChannelProtectionLevel"; //$NON-NLS-1$
 
     /**
      * Creates a new FTPS environment.
@@ -522,6 +523,18 @@ public class FTPSEnvironment extends FTPEnvironment {
         return this;
     }
 
+    /**
+     * Sets a data channel protection level required for secure data transmission.
+     *
+     * @param dataChannelProtectionLevel the data channel protection level
+     * @return This object.
+     * @see SSLSocket#setUseClientMode(boolean)
+     */
+    public FTPSEnvironment withDataChannelProtectionLevel(FTPSDataChannelProtectionLevel dataChannelProtectionLevel) {
+        put(DATA_CHANNEL_PROTECTION_LEVEL, dataChannelProtectionLevel);
+        return this;
+    }
+
     @Override
     FTPSClient createClient(String hostname, int port) throws IOException {
         SecurityMode securityMode = FileSystemProviderSupport.getValue(this, SECURITY_MODE, SecurityMode.class, SecurityMode.EXPLICIT);
@@ -595,6 +608,17 @@ public class FTPSEnvironment extends FTPEnvironment {
         if (containsKey(ENABLED_PROTOCOLS)) {
             String[] protocolVersions = FileSystemProviderSupport.getValue(this, ENABLED_PROTOCOLS, String[].class, null);
             client.setEnabledProtocols(protocolVersions);
+        }
+    }
+
+    void initializePostConnect( FTPSClient client ) throws IOException
+    {
+        super.initializePostConnect( client );
+        if (containsKey(DATA_CHANNEL_PROTECTION_LEVEL)) {
+            FTPSDataChannelProtectionLevel dataChannelProtectionLevel =
+                FileSystemProviderSupport.getValue(this, DATA_CHANNEL_PROTECTION_LEVEL, FTPSDataChannelProtectionLevel.class, null);
+            client.execPBSZ( 0 ); // 0 means streaming
+            client.execPROT( dataChannelProtectionLevel.name() );
         }
     }
 


### PR DESCRIPTION
Currently it is not possible to transfer data (even for the LIST command) with FTPS if the server requires secured data channels. This can be enabled by setting the DataChannelProtectionLevel.